### PR TITLE
feat(dice): simplify dice component to display only

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,7 +29,7 @@ function MainContent() {
         <div className="flex flex-grow items-center">
           <DiceGrid />
         </div>
-        <BottomBar />
+        {/* <BottomBar /> */}
         {theme === "pumpkin" && <FallingLeaves />}
       </div>
       <Toaster />

--- a/src/components/dice-grid.tsx
+++ b/src/components/dice-grid.tsx
@@ -1,9 +1,6 @@
-import { AnimatePresence, motion } from "framer-motion";
-import AddDice from "./add-dice";
+import { AnimatePresence } from "framer-motion";
 import Dice from "./dice";
 import useDiceStore from "@/zustand/diceStore";
-import { Button } from "./ui/button";
-import { Icon } from "@iconify/react/dist/iconify.js";
 import {
   DndContext,
   DragEndEvent,
@@ -16,7 +13,7 @@ import { SortableContext } from "@dnd-kit/sortable";
 import { useEffect, useState } from "react";
 
 const DiceGrid = () => {
-  const { dice, diceOrder, reorderDice } = useDiceStore();
+  const { dice, updateDice } = useDiceStore();
   const [isTouch, setIsTouch] = useState(false);
 
   const isTouchDevice = () => {
@@ -37,7 +34,7 @@ const DiceGrid = () => {
     const { active, over } = event;
 
     if (over && active.id !== over.id) {
-      reorderDice(Number(active.id), Number(over.id));
+      // TODO: implement reorder
     }
   };
 
@@ -45,55 +42,11 @@ const DiceGrid = () => {
     <DndContext sensors={useSensors(sensor)} onDragEnd={handleDragEnd}>
       <div className="flex-grow flex flex-wrap content-center justify-center items-center content-centergap-2 gap-2 max-w-screen-lg p-4">
         <AnimatePresence>
-          <SortableContext items={Array.from(new Set(diceOrder))}>
-            {diceOrder.map((diceId) => {
-              const { min, max, value, multiplier, isLocked, title } =
-                dice[diceId];
-              return (
-                <motion.div
-                  key={diceId}
-                  initial={{
-                    opacity: 0,
-                    scale: 0.8,
-                  }}
-                  animate={{
-                    opacity: 1,
-                    scale: 1,
-                  }}
-                  exit={{
-                    opacity: 0,
-                    scale: 0.8,
-                  }}
-                  transition={{
-                    duration: 0.1,
-                  }}
-                >
-                  <Dice
-                    id={diceId}
-                    min={min}
-                    max={max}
-                    value={value}
-                    multiplier={multiplier}
-                    isLocked={isLocked}
-                    title={title}
-                  />
-                </motion.div>
-              );
-            })}
+          <SortableContext items={dice.map((d) => d.id)}>
+            {dice.map((d) => (
+              <Dice key={d.id} dice={d} />
+            ))}
           </SortableContext>
-          <motion.div
-            layout
-            initial={{ opacity: 0, scale: 0.8 }}
-            animate={{ opacity: 1, scale: 1 }}
-            exit={{ opacity: 0, scale: 0.8 }}
-            transition={{ duration: 0.1 }}
-          >
-            <AddDice>
-              <Button size={"icon"} variant={"outline"} className="size-16">
-                <Icon icon="heroicons:plus-16-solid" />
-              </Button>
-            </AddDice>
-          </motion.div>
         </AnimatePresence>
       </div>
     </DndContext>

--- a/src/components/dice.tsx
+++ b/src/components/dice.tsx
@@ -1,202 +1,66 @@
-import { Button } from "./ui/button";
-import { motion } from "framer-motion";
-import { useToast } from "./ui/use-toast";
-import { ToastAction } from "./ui/toast";
-import MotionNumber from "motion-number";
-import { easeOut } from "framer-motion";
-import useDiceStore from "@/zustand/diceStore";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "./ui/dropdown-menu";
-import { Icon } from "@iconify/react/dist/iconify.js";
-import UpdateDice from "./update-dice";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import { useEffect, useRef, useState } from "react";
+import { DiceType } from "@/lib/types";
+import { easeOut } from "framer-motion";
+import MotionNumber from "motion-number";
 
 interface DiceProps {
-  id: number;
-  min: number;
-  max: number;
-  value: number;
-  multiplier: number;
-  isLocked: boolean;
-  title: string;
+  dice: DiceType;
 }
 
-const Dice = ({
-  id,
-  min,
-  max,
-  value,
-  multiplier,
-  isLocked,
-  title,
-}: DiceProps) => {
-    const { toggleLock, removeDice } = useDiceStore();
-    const [isOpen, setIsOpen] = useState(false);
-    const timeoutRef = useRef<NodeJS.Timeout | null>(null);
-    const { toast } = useToast();
-    const { undo } = useDiceStore.temporal.getState();
-    const {
-        attributes,
-        listeners,
-        setNodeRef,
-        transform,
-        transition,
-        isDragging,
-    } = useSortable({ id: id });
+const Dice = ({ dice }: DiceProps) => {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: dice.id });
 
-    const style = {
-        transform: CSS.Transform.toString(transform),
-        transition,
-        zIndex: isDragging ? 1000 : "auto",
-        position: "relative" as const,
-    };
-
-  const handleRemove = (id: number) => {
-    toast({
-      title: "Dice Removed",
-      description: `Dice with value ${value} and range ${min}-${max} ${
-        multiplier > 1 ? `×${multiplier}` : ""
-      } has been removed.`,
-      action: (
-        <ToastAction
-          altText="Undo"
-          onClick={() => {
-            undo();
-          }}
-        >
-          Undo
-        </ToastAction>
-      ),
-    });
-    removeDice(id);
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    zIndex: isDragging ? 1000 : "auto",
+    position: "relative" as const,
   };
 
-    const handleOpenChange = (open: boolean) => {
-        if (!isDragging) {
-            if (open) {
-                if (timeoutRef.current) clearTimeout(timeoutRef.current);
-                timeoutRef.current = setTimeout(() => setIsOpen(open), 200);
-            } else {
-                setIsOpen(false);
-                if (timeoutRef.current) clearTimeout(timeoutRef.current);
-            }
-        } else {
-            setIsOpen(false);
-        }
-    };
-
-    useEffect(() => {
-        if (isDragging) {
-            setIsOpen(false);
-            if (timeoutRef.current) clearTimeout(timeoutRef.current);
-        }
-    }, [isDragging]);
-
-    return (
-        <DropdownMenu open={isOpen} onOpenChange={handleOpenChange}>
-            <DropdownMenuTrigger asChild>
-                <motion.div
-                    animate={{ opacity: isLocked ? 0.3 : 1 }}
-                    transition={{ duration: 0.3 }}
-                    ref={setNodeRef}
-                    style={style}
-                    {...attributes}
-                    {...listeners}
-                    tabIndex={undefined}
-                >
-                    <Button
-                        size={"icon"}
-                        variant={"secondary"}
-                        className={`size-16 relative bg-secondary/80 hover:bg-secondary ${
-                            isOpen ? "bg-secondary" : ""
-                        } ${
-                            isDragging
-                                ? "bg-secondary z-50 ring-accent ring-2"
-                                : ""
-                        }`}
-                    >
-                        <div className="flex justify-center items-center flex-col z-50">
-                            <p className="text-xs text-secondary-foreground/60 whitespace-normal text-center">
-                                {title}
-                            </p>
-                            <p className="text-xl font-bold select-none">
-                                <MotionNumber
-                                    value={value}
-                                    format={{ notation: "compact" }}
-                                    transition={{
-                                        layout: {
-                                            type: "spring",
-                                            duration: isDragging ? 0 : 0.3,
-                                            bounce: 0,
-                                        },
-                                        y: {
-                                            type: "spring",
-                                            duration: 1.5,
-                                            bounce: 0.25,
-                                        },
-                                        opacity: {
-                                            duration: 1,
-                                            ease: easeOut,
-                                            times: [0, 0.3],
-                                        },
-                                    }}
-                                />
-                            </p>
-                        </div>
-                    </Button>
-                </motion.div>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent>
-                <DropdownMenuLabel>Manage</DropdownMenuLabel>
-                <DropdownMenuSeparator />
-                <DropdownMenuItem
-                    onSelect={(e) => {
-                        e.preventDefault();
-                    }}
-                    className="p-0"
-                >
-                    <UpdateDice diceId={id}>
-                        <div className="flex items-center gap-2 p-2 flex-grow">
-                            <Icon icon="heroicons:pencil-square-16-solid" />
-                            Edit
-                        </div>
-                    </UpdateDice>
-                </DropdownMenuItem>
-                <DropdownMenuItem
-                    onSelect={() => toggleLock(id)}
-                    className="gap-2"
-                >
-                    {isLocked ? (
-                        <>
-                            <Icon icon="heroicons:lock-open-16-solid" />
-                            <p>Unlock</p>
-                        </>
-                    ) : (
-                        <>
-                            <Icon icon="heroicons:lock-closed-20-solid" />
-                            <p>Lock</p>
-                        </>
-                    )}
-                </DropdownMenuItem>
-                <DropdownMenuSeparator />
-                <DropdownMenuItem
-                    className="text-red-600 focus:bg-red-600/25 focus:text-red-600 gap-2"
-                    onSelect={() => handleRemove(id)}
-                >
-                    <Icon icon="heroicons:trash-20-solid" />
-                    <p>Remove</p>
-                </DropdownMenuItem>
-            </DropdownMenuContent>
-        </DropdownMenu>
-    );
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      {...attributes}
+      {...listeners}
+      className="flex select-none justify-center items-center flex-col z-50 size-16 bg-secondary rounded-2xl"
+    >
+      <p className="text-xs text-secondary-foreground/60 whitespace-normal text-center">
+        {dice.config.title}
+      </p>
+      <p className="text-xl font-bold">
+        <MotionNumber
+          value={dice.value}
+          format={{ notation: "compact" }}
+          transition={{
+            layout: {
+              type: "spring",
+              duration: isDragging ? 0 : 0.3,
+              bounce: 0,
+            },
+            y: {
+              type: "spring",
+              duration: 1.5,
+              bounce: 0.25,
+            },
+            opacity: {
+              duration: 1,
+              ease: easeOut,
+              times: [0, 0.3],
+            },
+          }}
+        />
+      </p>
+    </div>
+  );
 };
 
 export default Dice;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,4 +1,4 @@
-export type Dice = {
+export type DiceType = {
   id: number;
   value: number;
   isLocked: boolean;


### PR DESCRIPTION
## What was done
- Stripped `Dice` down to display only — removed store access, toast, undo, dropdown, lock handler
- Added `useSortable` for drag and drop
- Changed props to accept a single `dice: DiceType` object instead of individual fields
- Reads from `dice.config.title` and `dice.value`